### PR TITLE
Make `exunit-verify` run tests associated with the current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Name                                      | Description
 ------------------------------------------|----------
 <kbd>exunit-verify-all</kbd>              | Run all the tests in the current project
 <kbd>exunit-verify-all-in-umbrella</kbd>  | Run all the tests in the current umbrella project
-<kbd>exunit-verify</kbd>                  | Run all the tests in the current buffer
+<kbd>exunit-verify</kbd>                  | Run all the tests associated with the current buffer
 <kbd>exunit-verify-single</kbd>           | Run the test under the point
 <kbd>exunit-rerun</kbd>                   | Re-run the last test invocation
 <kbd>exunit-toggle-file-and-test</kbd>  | Toggle between a file and its tests in the current window

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Name                                      | Description
 ------------------------------------------|----------
 <kbd>exunit-verify-all</kbd>              | Run all the tests in the current project
 <kbd>exunit-verify-all-in-umbrella</kbd>  | Run all the tests in the current umbrella project
-<kbd>exunit-verify</kbd>                  | Run all the tests associated with the current buffer
+<kbd>exunit-verify</kbd>                  | Run all the tests in the current buffer, or the test file corresponding to the current buffer
 <kbd>exunit-verify-single</kbd>           | Run the test under the point
 <kbd>exunit-rerun</kbd>                   | Re-run the last test invocation
 <kbd>exunit-toggle-file-and-test</kbd>  | Toggle between a file and its tests in the current window

--- a/exunit.el
+++ b/exunit.el
@@ -260,9 +260,12 @@ If the file does not exist, display an error message."
 
 ;;;###autoload
 (defun exunit-verify ()
-  "Run all the tests in the current buffer."
+  "Run all the tests associated with the current buffer."
   (interactive)
-  (exunit-compile (list (exunit-test-filename))))
+  (let ((filename (exunit-test-filename)))
+    (exunit-compile (list (if (exunit-test-file-p filename)
+                              filename
+                            (exunit-test-for-file filename))))))
 
 ;;;###autoload
 (defun exunit-toggle-file-and-test ()


### PR DESCRIPTION
If the current buffer is a test file, the behaviour of `exunit-verify` is the same as before: run all tests for in this file. Otherwise, e.g. it's an `.ex` source file in `lib/`, it tries to find the corresponding test file and run its tests.

It depends on changes from #7.