### PR TITLE
Support custom arguments

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,6 +27,8 @@ command.
 | =C-c , d=   | *exunit-debug* Run the test under the point in IEx shell. Supports IEx.pry method for debugging.              |
 | =C-c , 4 t= | *exunit-toggle-file-and-test-other-window* Toggle between a file and its tests in other window                |
 
-
+Invoking any of these commands with a prefix argument (`C-u`) will
+cause a prompt to be shown for additional arguments before the test(s)
+are run.
 
 [[https://raw.githubusercontent.com/ananthakumaran/exunit.el/master/screenshots/sample.png]]

--- a/exunit.el
+++ b/exunit.el
@@ -181,7 +181,10 @@ and filename relative to the dependency."
 (defun exunit-compile (args &optional directory)
   "Run mix test with the given ARGS."
   (let ((default-directory (or directory (exunit-project-root)))
-        (compilation-environment exunit-environment))
+        (compilation-environment exunit-environment)
+        (args (if current-prefix-arg
+                  `(,(read-from-minibuffer "Args: " (s-join " " args) nil nil 'exunit-arguments))
+                args)))
     (exunit-do-compile
      (s-join " " (append '("mix" "test") exunit-mix-test-default-options args)))))
 

--- a/exunit.el
+++ b/exunit.el
@@ -183,7 +183,7 @@ and filename relative to the dependency."
   (let ((default-directory (or directory (exunit-project-root)))
         (compilation-environment exunit-environment)
         (args (if current-prefix-arg
-                  `(,(read-from-minibuffer "Args: " (s-join " " args) nil nil 'exunit-arguments))
+                  (list (read-from-minibuffer "Args: " (s-join " " args) nil nil 'exunit-arguments))
                 args)))
     (exunit-do-compile
      (s-join " " (append '("mix" "test") exunit-mix-test-default-options args)))))


### PR DESCRIPTION
Fixes #9.

Sometimes I want to run `mix test` with custom command-line arguments (e.g. `mix test --exclude test --include api`).

This PR adds the ability to do that by invoking the `exunit-verify-*` commands with a prefix argument (e.g. `C-u C-c , s`). The user will be prompted for their custom command-line arguments, with the default being whatever default arguments they have configured.