### PR TITLE
Make exunit-mix-command and exunit-comit-command to accept an function.

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,12 +37,11 @@ test(s) are run.
 
 For example, you can redefine an `exunit-mix-command` to the following to execute in `backend` service context:
 
-```lisp
+#+begin_src emacs-lisp
 (setq exunit-mix-command
       (lambda (args)
         (let* ((args (s-join " " args))
                (mix-command (concat "'mix test " args "'")))
           ;; Adjust to your needs
           (list "docker-compose" "exec" "backend" "sh" "-c" mix-command))))
-
-```
+#+end_src

--- a/README.org
+++ b/README.org
@@ -32,3 +32,17 @@ cause a prompt to be shown for additional arguments before the
 test(s) are run.
 
 [[https://raw.githubusercontent.com/ananthakumaran/exunit.el/master/screenshots/sample.png]]
+
+* Run tests in a docker
+
+For example, you can redefine an `exunit-mix-command` to the following to execute in `backend` service context:
+
+```lisp
+(setq exunit-mix-command
+      (lambda (args)
+        (let* ((args (s-join " " args))
+               (mix-command (concat "'mix test " args "'")))
+          ;; Adjust to your needs
+          (list "docker-compose" "exec" "backend" "sh" "-c" mix-command))))
+
+```

--- a/exunit.el
+++ b/exunit.el
@@ -61,13 +61,13 @@
   "A command used to run the mix tool. Represented as list or function."
   :type '(choice (repeat string) function)
   :group 'exunit
-  :safe #'exunit-command-safe)
+  :risky t)
 
 (defcustom exunit-comint-command '("iex" "-S" "mix" "test" "--trace")
   "A command used to run the comint buffer. Represented as list or function."
   :type '(choice (repeat string) function)
   :group 'exunit
-  :safe #'exunit-command-safe)
+  :risky t)
 
 (defcustom exunit-mix-test-default-options '()
   "List of options that gets passed to the mix test command."
@@ -205,8 +205,8 @@ and filename relative to the dependency."
 
 To get a string representation of a command to pass to a compilation phase."
   (let ((command (if (functionp command-list-or-func)
-                         (funcall command-list-or-func args)
-                       (append command-list-or-func args))))
+                     (funcall command-list-or-func args)
+                   (append command-list-or-func args))))
     (s-join " " command)))
 
 (defun exunit-compile (args &optional directory)
@@ -289,13 +289,6 @@ If the file does not exist, display an error message."
     (if (file-exists-p filename)
         (funcall opener filename)
       (error "No source file found"))))
-
-(defun exunit-command-safe (value)
-  "Validate the value of exunit-mix-command/exunit-comint-command variables."
-  (cond
-   ((listp value) value) ; If the value is a list, return it as is.
-   ((functionp value) value) ; If the value is a function, return it as is.
-   (t (error "Invalid value for exunit-mix-command. Must be a list or a function."))))
 
 ;;; Public
 

--- a/exunit.el
+++ b/exunit.el
@@ -58,16 +58,16 @@
     ("4 t" "toggle other window" exunit-toggle-file-and-test-other-window)]])
 
 (defcustom exunit-mix-command '("mix" "test")
-  "List of commands used to run the mix tool."
-  :type '(repeat string)
+  "A command used to run the mix tool. Represented as list or function."
+  :type '(choice (repeat string) function)
   :group 'exunit
-  :safe #'listp)
+  :safe #'exunit-command-safe)
 
 (defcustom exunit-comint-command '("iex" "-S" "mix" "test" "--trace")
-  "List of commands used to run the comint buffer."
-  :type '(repeat string)
+  "A command used to run the comint buffer. Represented as list or function."
+  :type '(choice (repeat string) function)
   :group 'exunit
-  :safe #'listp)
+  :safe #'exunit-command-safe)
 
 (defcustom exunit-mix-test-default-options '()
   "List of options that gets passed to the mix test command."
@@ -200,22 +200,31 @@ and filename relative to the dependency."
   "Run command in comint mode."
   (pop-to-buffer (compile args 'exunit-iex-mode)))
 
+(defun exunit-build-command (command-list-or-func args)
+  "Combines exunit-comint-command or exunit-comint-command with arguments.
+
+To get a string representation of a command to pass to a compilation phase."
+  (let ((command (if (functionp command-list-or-func)
+                         (funcall command-list-or-func args)
+                       (append command-list-or-func args))))
+    (s-join " " command)))
+
 (defun exunit-compile (args &optional directory)
   "Run mix test with the given ARGS."
-  (let ((default-directory (or directory (exunit-project-root)))
-        (compilation-environment exunit-environment)
-        (args (if-let (infixes (transient-args 'exunit-transient))
-                  (append infixes args)
-                args)))
-    (exunit-do-compile
-     (s-join " " (append exunit-mix-command exunit-mix-test-default-options args)))))
+  (let* ((default-directory (or directory (exunit-project-root)))
+         (compilation-environment exunit-environment)
+         (args (if-let (infixes (transient-args 'exunit-transient))
+                   (append infixes args)
+                 args))
+         (args (append exunit-mix-test-default-options args)))
+    (exunit-do-compile (exunit-build-command exunit-mix-command args))))
 
 (defun exunit-comint (args &optional directory)
   "Run mix test in iex shell with the given ARGS."
-  (let ((default-directory (or directory (exunit-project-root)))
-        (compilation-environment exunit-environment))
-    (exunit-do-comint
-     (s-join " " (append exunit-comint-command exunit-mix-test-default-options args)))))
+  (let* ((default-directory (or directory (exunit-project-root)))
+         (compilation-environment exunit-environment)
+         (args (append exunit-mix-test-default-options args)))
+    (exunit-do-comint (exunit-build-command exunit-comint-command args))))
 
 (defun exunit-test-file-p (file)
   "Return non-nil if FILE is an ExUnit test file."
@@ -280,6 +289,13 @@ If the file does not exist, display an error message."
     (if (file-exists-p filename)
         (funcall opener filename)
       (error "No source file found"))))
+
+(defun exunit-command-safe (value)
+  "Validate the value of exunit-mix-command/exunit-comint-command variables."
+  (cond
+   ((listp value) value) ; If the value is a list, return it as is.
+   ((functionp value) value) ; If the value is a function, return it as is.
+   (t (error "Invalid value for exunit-mix-command. Must be a list or a function."))))
 
 ;;; Public
 


### PR DESCRIPTION
Just appending arguments at the end of an `exunit-mix-command` is not enough for complex examples like this:

`docker-compose exec backend sh -c 'mix test test/emails/loans_test.exs:17'`

It is mandatory to have an apostrophe at the end. 

So this MR gives ability to set `exunit-mix-command` and `exunit-comit-command` as a function.