### PR TITLE
add --exclude option

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@ command.
 (setq transient-default-level 5) ;; default is 4
 #+end_src
 
-Currently, the only extra switch that is shown is `--exclude`.
+Currently, the only extra switch that is shown is =--exclude=.
 
 * Commands
 

--- a/README.org
+++ b/README.org
@@ -12,7 +12,12 @@ command.
 
 #+begin_src emacs-lisp
 (add-hook 'elixir-mode-hook 'exunit-mode)
+
+;; Optionally configure `transient-default-level' to 5 to show extra switches
+(setq transient-default-level 5) ;; default is 4
 #+end_src
+
+Currently, the only extra switch that is shown is `--exclude`.
 
 * Commands
 

--- a/README.org
+++ b/README.org
@@ -14,6 +14,7 @@ command.
 (add-hook 'elixir-mode-hook 'exunit-mode)
 
 ;; Optionally configure `transient-default-level' to 5 to show extra switches
+;; Or use `C-x l' to change the level of individual commands and switches
 (setq transient-default-level 5) ;; default is 4
 #+end_src
 

--- a/exunit.el
+++ b/exunit.el
@@ -39,13 +39,21 @@
 
 ;;; Private
 
+(transient-define-infix exunit-transient:--exclude ()
+  :description "Exclude"
+  :class 'transient-option
+  :multi-value 'repeat
+  :shortarg "-e"
+  :argument "--exclude=")
+
 (transient-define-prefix exunit-transient ()
   "ExUnit"
   ["Arguments"
    [("-f" "Failed" "--failed")
     ("-s" "Stale" "--stale")
     ("-t" "Trace" "--trace")
-    ("-c" "Coverage" "--cover")]
+    ("-c" "Coverage" "--cover")
+    (exunit-transient:--exclude)]
    [("-z" "Slowest" "--slowest=10")
     ("-m" "Fail Fast" "--max-failures=1")]]
   ["Actions"

--- a/exunit.el
+++ b/exunit.el
@@ -53,7 +53,7 @@
     ("-s" "Stale" "--stale")
     ("-t" "Trace" "--trace")
     ("-c" "Coverage" "--cover")
-    (exunit-transient:--exclude)]
+    (exunit-transient:--exclude :level 5)]
    [("-z" "Slowest" "--slowest=10")
     ("-m" "Fail Fast" "--max-failures=1")]]
   ["Actions"


### PR DESCRIPTION
I often need to use the `--exclude` option. This PR adds support for it.

Thanks to transient, it also supports supplying multiple `--exclude` options and the values supplied can even be saved for later invocations by `transient-set` usually bound to `C-x s` (See [Saving Values](https://www.gnu.org/software/emacs/manual/html_mono/transient.html#Saving-Values)).

<img width="800" alt="Screenshot 2023-11-17 at 13 06 11" src="https://github.com/ananthakumaran/exunit.el/assets/3605049/e94f00b5-7fcd-4c03-b785-c64661143710">
