### PR TITLE
add support for --seed flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@ command.
 (setq transient-default-level 5) ;; default is 4
 #+end_src
 
-Currently, 2 extra switches are shown, =--exclude= and =--include=.
+Currently, 3 extra switches are shown, =--exclude=, =--include= and =--seed=.
 
 * Commands
 

--- a/exunit.el
+++ b/exunit.el
@@ -54,6 +54,12 @@
   :shortarg "-i"
   :argument "--include=")
 
+(transient-define-infix exunit-transient:--seed ()
+  :description "Seed"
+  :class 'transient-option
+  :shortarg "-S"
+  :argument "--seed=")
+
 (transient-define-prefix exunit-transient ()
   "ExUnit"
   ["Arguments"
@@ -62,7 +68,8 @@
     ("-t" "Trace" "--trace")
     ("-c" "Coverage" "--cover")
     (exunit-transient:--exclude :level 5)
-    (exunit-transient:--include :level 5)]
+    (exunit-transient:--include :level 5)
+    (exunit-transient:--seed :level 5)]
    [("-z" "Slowest" "--slowest=10")
     ("-m" "Fail Fast" "--max-failures=1")]]
   ["Actions"


### PR DESCRIPTION
Closely mimicking the functionality of the --include and --exclude flags, this PR introduces the ability to specify the --seed flag.

Since the -s shortarg is already taken, I opted for using -S for the seed. Feel free to suggest something different.

Fixes: #22