### PR TITLE
add support for --repeat-until-failure flag

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,8 @@ command.
 (setq transient-default-level 5) ;; default is 4
 #+end_src
 
-Currently, 3 extra switches are shown, =--exclude=, =--include= and =--seed=.
+Currently, 4 extra switches are shown, =--exclude=, =--include=, =--seed= and
+=--repeat-until-failure=.
 
 * Commands
 

--- a/exunit.el
+++ b/exunit.el
@@ -60,6 +60,12 @@
   :shortarg "-S"
   :argument "--seed=")
 
+(transient-define-infix exunit-transient:--repeat-until-failure ()
+  :description "Repeat until failure"
+  :class 'transient-option
+  :shortarg "-R"
+  :argument "--repeat-until-failure=")
+
 (transient-define-prefix exunit-transient ()
   "ExUnit"
   ["Arguments"
@@ -69,7 +75,8 @@
     ("-c" "Coverage" "--cover")
     (exunit-transient:--exclude :level 5)
     (exunit-transient:--include :level 5)
-    (exunit-transient:--seed :level 5)]
+    (exunit-transient:--seed :level 5)
+    (exunit-transient:--repeat-until-failure :level 5)]
    [("-z" "Slowest" "--slowest=10")
     ("-m" "Fail Fast" "--max-failures=1")]]
   ["Actions"


### PR DESCRIPTION
This PR introduces the ability to specify the --repeat-until-failure flag. I opted for using -R for this flag, since is this is a quite specialized flag that we don't expect people to run all the time.